### PR TITLE
Support ES5

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,10 +11,10 @@ function replacePath(str, addSuffix) {
     var fpath = addSuffix ? tmp[0] + ".ngfactory" : tmp[0];
     var moduleName;
     if (tmp.length < 2) {
-      return 'require("' + fpath + '")()';
+      return 'require("' + fpath + '")() }';
     } else {
       moduleName = addSuffix ? tmp[1] + "NgFactory" : tmp[1]
-      return 'require("' + fpath + '")("' + moduleName + '")';
+      return 'require("' + fpath + '")("' + moduleName + '") }';
     }
   });
 }
@@ -39,7 +39,7 @@ module.exports = function(source) {
   var newSource = source.replace(loadChildrenRegex, function(match, path) {
     var trimmed = path.trim();
     if (trimmed[0] !== '"' && trimmed[0] !== "'") return match;
-    return 'loadChildren: () =>' + replacePath(path, addSuffix);
+    return 'loadChildren: function loadChildren() { return' + replacePath(path, addSuffix);
   });
   return newSource;
 };

--- a/test/spec.js
+++ b/test/spec.js
@@ -5,27 +5,27 @@ describe("angular2-load-children-loader", function() {
 
   it("returns require expression without suffix when JiT context", function () {
     var inputSource = `{ loadChildren: "./subModule#SubModule" }`;
-    var expected    = `{ loadChildren: () => require("./subModule")("SubModule") }`;
+    var expected    = `{ loadChildren: function loadChildren() { return require("./subModule")("SubModule") } }`;
     var actual = loader.bind({ cacheable: false, resourcePath: "./app.routing.ts" })(inputSource);
     assert.equal(actual, expected);
   });
 
   it("returns require expression without suffix when JiT context, single quote", function () {
     var inputSource = `{ loadChildren: './subModule#SubModule' }`;
-    var expected    = `{ loadChildren: () => require("./subModule")("SubModule") }`;
+    var expected    = `{ loadChildren: function loadChildren() { return require("./subModule")("SubModule") } }`;
     var actual = loader.bind({ cacheable: false, resourcePath: "./app.routing.ts" })(inputSource);
     assert.equal(actual, expected);
   });
 
   it("returns require expression with 'ngfactory' suffix when AoT context", function () {
     var inputSource = `{ loadChildren: "./subModule#SubModule" }`;
-    var expected    = `{ loadChildren: () => require("./subModule.ngfactory")("SubModuleNgFactory") }`;
+    var expected    = `{ loadChildren: function loadChildren() { return require("./subModule.ngfactory")("SubModuleNgFactory") } }`;
     var actual = loader.bind({ cacheable: false, resourcePath: "./app.module.ngfactory.ts" })(inputSource);
     assert.equal(actual, expected);
   });
 
   it("pass through loadChildren property is not string", function () {
-    var inputSource = `{ loadChildren: () => "./subModule#SubModule" }`;
+    var inputSource = `{ loadChildren: function loadChildren() { return "./subModule#SubModule" } }`;
     var actual = loader.bind({ cacheable: false, resourcePath: "./app.routing.ts" })(inputSource);
     assert.equal(actual, inputSource);
   });


### PR DESCRIPTION
Instead of emitting an ES6 arrow function which then has to be transpiled, why not just emit a ES5 function so end user doesn't have to transpile afterwards?